### PR TITLE
Shuffle cir's before being sorted by pool priority

### DIFF
--- a/pkg/server/commands/acquire.go
+++ b/pkg/server/commands/acquire.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"sort"
 
@@ -67,6 +68,8 @@ func (c *acquireCmd) Run() error {
 			cirs = append(cirs, r)
 		}
 	}
+
+	rand.Shuffle(len(cirs), func(i, j int) { cirs[i], cirs[j] = cirs[j], cirs[i] })
 
 	sort.SliceStable(cirs, func(i, j int) bool {
 		cir0 := cirs[i]


### PR DESCRIPTION
Prevents some cir's in a pool being favoured