### PR TITLE
Deploy manifests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17-alpine as builder
+FROM golang:1.17-alpine3.16 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -19,12 +19,17 @@ COPY pkg/ pkg/
 # Build the operator
 RUN apk add libc-dev gcc
 RUN apk add libvirt-dev
-RUN go build -a -o ofcir-operator main.go
+RUN CGO_ENABLED=1 go build -a -o ofcir-operator main.go
 
 # Build the api server
 RUN CGO_ENABLED=0 go build -a -o ofcir-api cmd/ofcir-api/main.go
 
-FROM redhat/ubi8
+# Cleanup 
+FROM alpine:3.16
+
+RUN apk add libc-dev gcc
+RUN apk add libvirt-dev
+
 WORKDIR /
 COPY --from=builder /workspace/ofcir-operator .
 COPY --from=builder /workspace/ofcir-api .

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+IMG ?= ofcir:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23
 
@@ -67,8 +67,8 @@ docs: ## Generate the doc assests
 
 .PHONY: build
 build: generate fmt vet ## Build manager binary.
-	go build -o bin/ofcir-operator main.go
-	go build -o bin/ofcir-api cmd/ofcir-api/main.go
+	CGO_ENABLED=1 go build -o bin/ofcir-operator main.go
+	CGO_ENABLED=0 go build -o bin/ofcir-api cmd/ofcir-api/main.go
 
 .PHONY: unit-tests
 unit-tests: fmt vet
@@ -87,6 +87,12 @@ docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
 
 ##@ Deployment
+
+## Location for storing the manifests to be deployed in the target cluster
+DEPLOY_MANIFESTS_DIR ?= $(shell pwd)/ofcir-manifests
+$(DEPLOY_MANIFESTS_DIR):
+	mkdir -p $(DEPLOY_MANIFESTS_DIR)
+
 
 ifndef ignore-not-found
   ignore-not-found = false
@@ -108,6 +114,17 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+
+.PHONY: generate-deploy-manifests
+generate-deploy-manifests: $(DEPLOY_MANIFESTS_DIR) manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	$(KUSTOMIZE) build config/default > $(DEPLOY_MANIFESTS_DIR)/ofcir-operator.yaml
+
+.PHONY: test-deploy
+test-deploy: generate-deploy-manifests
+	minikube image build -t ofcir.io/ofcir:latest .
+	kubectl delete deployment ofcir-controller-manager
+	kubectl apply -f $(DEPLOY_MANIFESTS_DIR)/ofcir-operator.yaml
 
 ##@ Build Dependencies
 

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,9 @@ generate-deploy-manifests: $(DEPLOY_MANIFESTS_DIR) manifests kustomize ## Deploy
 .PHONY: test-deploy
 test-deploy: generate-deploy-manifests
 	minikube image build -t ofcir.io/ofcir:latest .
-	kubectl delete deployment ofcir-controller-manager
+	kubectl delete deployment ofcir-controller-manager || true
+	kubectl delete svc ofcir-service || true
+
 	kubectl apply -f $(DEPLOY_MANIFESTS_DIR)/ofcir-operator.yaml
 
 ##@ Build Dependencies

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ so that it will be possible to have a more efficient resource management and a m
 
 ## Getting Started
 
-Since we'll need a Kubernetes cluster to run against the ooperator, [Minikube](https://minikube.sigs.k8s.io/) could be used to quickly setup one. The following command could be used to install it
+Since we'll need a Kubernetes cluster to run against the operator, [Minikube](https://minikube.sigs.k8s.io/) could be used to quickly setup one. The following command could be used to install it
 on a Fedora laptop:
 
 ```

--- a/cmd/ofcir-api/main.go
+++ b/cmd/ofcir-api/main.go
@@ -10,7 +10,7 @@ func main() {
 	var kubeconfig, port, namespace string
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file")
 	flag.StringVar(&port, "port", "8087", "server port")
-	flag.StringVar(&namespace, "namespace", "default", "Namespace to look for CIPool and CIR resources")
+	flag.StringVar(&namespace, "namespace", "ofcir-system", "Namespace to look for CIPool and CIR resources")
 	flag.Parse()
 
 	srv := server.NewOfcirAPI(port, namespace)

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -27,7 +27,7 @@ spec:
           requests:
             cpu: 5m
             memory: 64Mi
-      - name: manager
+      - name: ofcir-operator
         args:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     spec:
       containers:
-      - name: manager
+      - name: ofcir-operator
         args:
         - "--config=controller_manager_config.yaml"
         volumeMounts:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,6 +5,12 @@ generatorOptions:
   disableNameSuffixHash: true
 
 configMapGenerator:
-- name: manager-config
-  files:
+- files:
   - controller_manager_config.yaml
+  name: manager-config
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: ofcir
+  newTag: latest

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -25,14 +25,15 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
-        runAsNonRoot: true
+        runAsUser: 1001
       containers:
       - command:
-        - /manager
+        - /ofcir-operator
         args:
         - --leader-elect
-        image: controller:latest
-        name: manager
+        image: ofcir.io/ofcir:latest
+        imagePullPolicy: IfNotPresent
+        name: ofcir-operator
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:
@@ -47,6 +48,25 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
+      # - command:
+      #   - /ofcir-api
+      #   image: ofcir.io/ofcir:latest
+      #   imagePullPolicy: IfNotPresent
+      #   name: ofcir-api
+      #   securityContext:
+      #     allowPrivilegeEscalation: false
+      #   livenessProbe:
+      #     httpGet:
+      #       path: /healthz
+      #       port: 8082
+      #     initialDelaySeconds: 15
+      #     periodSeconds: 20
+      #   readinessProbe:
+      #     httpGet:
+      #       path: /readyz
+      #       port: 8082
+      #     initialDelaySeconds: 5
+      #     periodSeconds: 10
         # TODO(user): Configure the resources accordingly based on the project requirements.
         # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         resources:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -5,6 +5,22 @@ metadata:
     control-plane: controller-manager
   name: system
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service
+  labels:
+    control-plane: controller-manager
+spec:
+  type: NodePort
+  ports:
+  - port: 8087
+    targetPort: 8087
+    protocol: TCP
+    name: http
+  selector:
+    control-plane: controller-manager
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -48,25 +64,15 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-      # - command:
-      #   - /ofcir-api
-      #   image: ofcir.io/ofcir:latest
-      #   imagePullPolicy: IfNotPresent
-      #   name: ofcir-api
-      #   securityContext:
-      #     allowPrivilegeEscalation: false
-      #   livenessProbe:
-      #     httpGet:
-      #       path: /healthz
-      #       port: 8082
-      #     initialDelaySeconds: 15
-      #     periodSeconds: 20
-      #   readinessProbe:
-      #     httpGet:
-      #       path: /readyz
-      #       port: 8082
-      #     initialDelaySeconds: 5
-      #     periodSeconds: 10
+      - command:
+        - /ofcir-api
+        image: ofcir.io/ofcir:latest
+        imagePullPolicy: IfNotPresent
+        name: ofcir-api
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - containerPort: 8087
         # TODO(user): Configure the resources accordingly based on the project requirements.
         # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         resources:

--- a/config/rbac/cipool_editor_role.yaml
+++ b/config/rbac/cipool_editor_role.yaml
@@ -1,8 +1,9 @@
 # permissions for end users to edit cipools.
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: cipool-editor-role
+  namespace: system
 rules:
 - apiGroups:
   - ofcir.openshift

--- a/config/rbac/cipool_viewer_role.yaml
+++ b/config/rbac/cipool_viewer_role.yaml
@@ -1,8 +1,9 @@
 # permissions for end users to view cipools.
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: cipool-viewer-role
+  namespace: system
 rules:
 - apiGroups:
   - ofcir.openshift

--- a/config/rbac/ciresource_editor_role.yaml
+++ b/config/rbac/ciresource_editor_role.yaml
@@ -1,8 +1,9 @@
 # permissions for end users to edit ciresources.
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: ciresource-editor-role
+  namespace: system
 rules:
 - apiGroups:
   - ofcir.openshift

--- a/config/rbac/ciresource_viewer_role.yaml
+++ b/config/rbac/ciresource_viewer_role.yaml
@@ -1,8 +1,9 @@
 # permissions for end users to view ciresources.
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: ciresource-viewer-role
+  namespace: system
 rules:
 - apiGroups:
   - ofcir.openshift

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: leader-election-rolebinding
+  namespace: system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,10 +1,23 @@
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   creationTimestamp: null
   name: manager-role
+  namespace: ofcir-system
 rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - ofcir.openshift
   resources:
@@ -12,6 +25,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -38,6 +52,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,10 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: manager-rolebinding
+  namespace: system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: manager-role
 subjects:
 - kind: ServiceAccount

--- a/config/samples/ofcir_v1_cipool_fake.yaml
+++ b/config/samples/ofcir_v1_cipool_fake.yaml
@@ -1,0 +1,13 @@
+apiVersion: ofcir.openshift/v1
+kind: CIPool
+metadata:
+  name: cipool-fake
+  namespace: ofcir-system
+spec:
+  provider: fake-provider
+  priority: 0
+  size: 5
+  timeout: '4h'
+  state: available
+  type: host
+

--- a/controllers/cipool_controller.go
+++ b/controllers/cipool_controller.go
@@ -38,6 +38,9 @@ import (
 	ofcirv1 "github.com/openshift/ofcir/api/v1"
 )
 
+// Additional permissions required by the controller
+//+kubebuilder:rbac:groups="",namespace=ofcir-system,resources=secrets,verbs=get;list;watch;create;update;patch;delete
+
 const (
 	defaultCIPoolRetryDelay = time.Minute * 1
 )
@@ -48,9 +51,9 @@ type CIPoolReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=ofcir.openshift,resources=cipools,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=ofcir.openshift,resources=cipools/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=ofcir.openshift,resources=cipools/finalizers,verbs=update
+//+kubebuilder:rbac:groups=ofcir.openshift,namespace=ofcir-system,resources=cipools,verbs=get;list;watch;create;update;patch;delete;deletecollection
+//+kubebuilder:rbac:groups=ofcir.openshift,namespace=ofcir-system,resources=cipools/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=ofcir.openshift,namespace=ofcir-system,resources=cipools/finalizers,verbs=update
 
 // Reconcile handles changes to the CIPool type
 func (r *CIPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/controllers/ciresource_controller.go
+++ b/controllers/ciresource_controller.go
@@ -40,9 +40,9 @@ type CIResourceReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=ofcir.openshift,resources=ciresources,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=ofcir.openshift,resources=ciresources/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=ofcir.openshift,resources=ciresources/finalizers,verbs=update
+//+kubebuilder:rbac:groups=ofcir.openshift,namespace=ofcir-system,resources=ciresources,verbs=get;list;watch;create;update;patch;delete;deletecollection
+//+kubebuilder:rbac:groups=ofcir.openshift,namespace=ofcir-system,resources=ciresources/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=ofcir.openshift,namespace=ofcir-system,resources=ciresources/finalizers,verbs=update
 
 // Reconcile handles changes to the CIResource type
 func (r *CIResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/docs/dev/deployment.md
+++ b/docs/dev/deployment.md
@@ -1,0 +1,4 @@
+1. minikube start --driver=podman
+2. minikube image build -t ofcir.io/ofcir:latest .
+3. make generate-deploy-manifests
+4. kubectl apply -f ofcir-manifests/

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -54,6 +55,8 @@ func main() {
 	var probeAddr string
 	var webhookPort int
 
+	fmt.Println("*")
+
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8085", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8086", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -70,12 +73,14 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:                 scheme,
-		MetricsBindAddress:     metricsAddr,
-		Port:                   webhookPort,
-		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "7c25506c.openshift",
+		Scheme:                  scheme,
+		MetricsBindAddress:      metricsAddr,
+		Port:                    webhookPort,
+		HealthProbeBindAddress:  probeAddr,
+		LeaderElection:          enableLeaderElection,
+		LeaderElectionID:        "7c25506c.openshift",
+		LeaderElectionNamespace: "ofcir-system",
+		Namespace:               "ofcir-system",
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/ofcir-manifests/ofcir-operator.yaml
+++ b/ofcir-manifests/ofcir-operator.yaml
@@ -1,0 +1,534 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: ofcir-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: cipools.ofcir.openshift
+spec:
+  group: ofcir.openshift
+  names:
+    kind: CIPool
+    listKind: CIPoolList
+    plural: cipools
+    shortNames:
+    - cip
+    singular: cipool
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The provider used by the pool to manage the resources
+      jsonPath: .spec.provider
+      name: Provider
+      type: string
+    - description: The priority of the pool
+      jsonPath: .spec.priority
+      name: Priority
+      type: integer
+    - description: The current state
+      jsonPath: .status.state
+      name: State
+      type: string
+    - description: The current size of the pool
+      jsonPath: .status.size
+      name: Size
+      type: integer
+    - description: The requested size of the pool
+      jsonPath: .spec.size
+      name: Req Size
+      type: integer
+    - description: The type of the pool
+      jsonPath: .spec.type
+      name: Type
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: CIPool is the Schema for the cipools API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CIPoolSpec defines the desired state of CIPool
+            properties:
+              priority:
+                description: Used for selecting an eligible pool
+                type: integer
+              provider:
+                description: Identifies the kind of the pool
+                type: string
+              providerInfo:
+                description: Store any useful instance info specific to the current provider type
+                type: string
+              size:
+                description: Desired number of instances maintained by the current pool
+                type: integer
+              state:
+                description: Required state of the pool
+                type: string
+              timeout:
+                description: Specify how long a CIR instance will be allowed to remain in the inuse state
+                type: string
+              type:
+                description: The type of the resources managed by the pool
+                type: string
+            required:
+            - priority
+            - provider
+            - size
+            - state
+            - timeout
+            - type
+            type: object
+          status:
+            description: CIPoolStatus defines the observed state of CIPool
+            properties:
+              lastUpdated:
+                description: LastUpdated identifies when this status was last observed.
+                format: date-time
+                type: string
+              size:
+                description: Current number of instances maintained by the current pool
+                type: integer
+              state:
+                description: Current state of the pool
+                type: string
+            required:
+            - size
+            - state
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: ciresources.ofcir.openshift
+spec:
+  group: ofcir.openshift
+  names:
+    kind: CIResource
+    listKind: CIResourceList
+    plural: ciresources
+    shortNames:
+    - cir
+    singular: ciresource
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Public IPv4 address
+      jsonPath: .status.address
+      name: Address
+      type: string
+    - description: Current state
+      jsonPath: .status.state
+      name: State
+      type: string
+    - description: Requested state
+      jsonPath: .spec.state
+      name: Req State
+      type: string
+    - description: Pool owning the current resource
+      jsonPath: .spec.poolRef.name
+      name: Pool
+      type: string
+    - description: Resource Id
+      jsonPath: .status.resourceId
+      name: Res Id
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: CIResource represents a physical allocated instance (or set of instances) from a specific pool
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CIResourceSpec defines the desired state of CIResource
+            properties:
+              extra:
+                description: Additional information to support clusters
+                type: string
+              poolRef:
+                description: Reference to the CIPool that is managing the current CIResource
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+              state:
+                description: The desired state for the CIResource
+                type: string
+              type:
+                description: The type of the current resource
+                type: string
+            required:
+            - extra
+            - poolRef
+            - state
+            - type
+            type: object
+          status:
+            description: CIResourceStatus defines the observed state of CIResource
+            properties:
+              address:
+                description: Public IPv4 address
+                type: string
+              extra:
+                description: This field may contain extra data that may vary depending on the specific resource type used
+                type: string
+              lastUpdated:
+                description: LastUpdated identifies when this status was last observed.
+                format: date-time
+                type: string
+              providerInfo:
+                description: Store any useful instance info specific to the current provider type
+                type: string
+              resourceId:
+                description: The unique identifier of the resource currently requested
+                type: string
+              state:
+                description: Current state of the resource
+                type: string
+            required:
+            - address
+            - resourceId
+            - state
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ofcir-controller-manager
+  namespace: ofcir-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ofcir-leader-election-role
+  namespace: ofcir-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: ofcir-manager-role
+  namespace: ofcir-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ofcir.openshift
+  resources:
+  - cipools
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ofcir.openshift
+  resources:
+  - cipools/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ofcir.openshift
+  resources:
+  - cipools/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ofcir.openshift
+  resources:
+  - ciresources
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ofcir.openshift
+  resources:
+  - ciresources/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ofcir.openshift
+  resources:
+  - ciresources/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ofcir-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ofcir-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ofcir-leader-election-rolebinding
+  namespace: ofcir-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ofcir-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: ofcir-controller-manager
+  namespace: ofcir-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ofcir-manager-rolebinding
+  namespace: ofcir-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ofcir-manager-role
+subjects:
+- kind: ServiceAccount
+  name: ofcir-controller-manager
+  namespace: ofcir-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ofcir-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ofcir-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: ofcir-controller-manager
+  namespace: ofcir-system
+---
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    kind: ControllerManagerConfig
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: 127.0.0.1:8080
+    webhook:
+      port: 9443
+    leaderElection:
+      leaderElect: true
+      resourceName: 7c25506c.openshift
+kind: ConfigMap
+metadata:
+  name: ofcir-manager-config
+  namespace: ofcir-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: ofcir-controller-manager-metrics-service
+  namespace: ofcir-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: ofcir-controller-manager
+  namespace: ofcir-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: ofcir-operator
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+      - args:
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=127.0.0.1:8080
+        - --leader-elect
+        command:
+        - /ofcir-operator
+        image: ofcir.io/ofcir:latest
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: ofcir-operator
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+      securityContext:
+        runAsUser: 1001
+      serviceAccountName: ofcir-controller-manager
+      terminationGracePeriodSeconds: 10

--- a/ofcir-manifests/ofcir-operator.yaml
+++ b/ofcir-manifests/ofcir-operator.yaml
@@ -460,6 +460,23 @@ spec:
   selector:
     control-plane: controller-manager
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: ofcir-service
+  namespace: ofcir-system
+spec:
+  ports:
+  - name: http
+    port: 8087
+    protocol: TCP
+    targetPort: 8087
+  selector:
+    control-plane: controller-manager
+  type: NodePort
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -475,7 +492,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: ofcir-operator
+        kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
     spec:
@@ -519,6 +536,15 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
+        securityContext:
+          allowPrivilegeEscalation: false
+      - command:
+        - /ofcir-api
+        image: ofcir.io/ofcir:latest
+        imagePullPolicy: IfNotPresent
+        name: ofcir-api
+        ports:
+        - containerPort: 8087
         resources:
           limits:
             cpu: 500m


### PR DESCRIPTION
This patch starts introducing all the necessary code/manifests for generating the manifests to be used for deploying the operator in a cluster