### PR TITLE
Ironic: Add support for ssh key

### DIFF
--- a/config/samples/ofcir_v1_cipool.yaml
+++ b/config/samples/ofcir_v1_cipool.yaml
@@ -110,7 +110,8 @@ stringData:
       "username": "ironic-user",
       "password": "XXXX",
       "endpoint": "https://172.22.0.3:6385",
-      "image": "http://172.22.0.1/images/ofcir_image.qcow2"
+      "image": "http://172.22.0.1/images/ofcir_image.qcow2",
+      "sshkey": "ssh-rsa ...."
     }
 ---
 


### PR DESCRIPTION
Add support to include the ssh key in a config drive for ironic nodes.