### PR TITLE
Have ironic provider populate extra data

### DIFF
--- a/pkg/providers/ironic.go
+++ b/pkg/providers/ironic.go
@@ -111,6 +111,7 @@ func (p *ironicProvider) AcquireCompleted(id string) (bool, Resource, error) {
 	}
 
 	res.Address, _ = node.Extra["ip"].(string)
+	res.Metadata, _ = node.Extra["data"].(string)
 	return true, res, nil
 }
 


### PR DESCRIPTION
Extra data is used for cluster details