### PR TITLE
Don't release fallback resources not yet provisioned

### DIFF
--- a/controllers/ciresource_fsm.go
+++ b/controllers/ciresource_fsm.go
@@ -188,8 +188,11 @@ func (f *CIResourceFSM) handleStateCleaning(context CIResourceFSMContext) (time.
 
 	// If it's a fallback resource, let's clean and release it immediately
 	if context.CIPool.IsFallbackPool() {
-		if err := context.Provider.Release(context.CIResource.Status.ResourceId); err != nil {
-			if !errors.As(err, &providers.ResourceNotFoundError{}) {
+
+		// Do not delete a fallback resource that was not yet created
+		if context.CIResource.Status.ResourceId != fallbackResourceID {
+			err := context.Provider.Release(context.CIResource.Status.ResourceId)
+			if err != nil && !errors.As(err, &providers.ResourceNotFoundError{}) {
 				return defaultCIPoolRetryDelay, err
 			}
 		}


### PR DESCRIPTION
In some circumnstances the client may decide to prematurely release a resource while the underlying provider was not yet invoked.
For fallback resources this means trying to delete a non-existent instance, thus the reconcile loop will remain stuck in the `cleaning` state due the failing delete (and the CIR resource locked).