### PR TITLE
Add ibmcloud provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.20.1
 	github.com/packethost/packngo v0.28.0
+	github.com/softlayer/softlayer-go v1.1.2
 	github.com/stretchr/testify v1.8.3
 	go.etcd.io/etcd v3.3.27+incompatible
 	k8s.io/api v0.25.15
@@ -40,6 +41,7 @@ require (
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/softlayer/xmlrpc v0.0.0-20200409220501-5f089df7cb7e // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	golang.org/x/arch v0.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -273,6 +273,7 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/jarcoal/httpmock v1.0.5 h1:cHtVEcTxRSX4J0je7mWPfc9BpDpqzXSJ5HbymZmyHck=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
@@ -375,6 +376,10 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
+github.com/softlayer/softlayer-go v1.1.2 h1:rUSSGCyaxymvTOsaFjwr+cGxA8muw3xg2LSrIMNcN/c=
+github.com/softlayer/softlayer-go v1.1.2/go.mod h1:hvAbzGH4LRXA6yXY8BNx99yoqZ7urfDdtl9mvBf0G+g=
+github.com/softlayer/xmlrpc v0.0.0-20200409220501-5f089df7cb7e h1:3OgWYFw7jxCZPcvAg+4R8A50GZ+CCkARF10lxu2qDsQ=
+github.com/softlayer/xmlrpc v0.0.0-20200409220501-5f089df7cb7e/go.mod h1:fKZCUVdirrxrBpwd9wb+lSoVixvpwAu8eHzbQB2tums=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/pkg/providers/ibmcloud.go
+++ b/pkg/providers/ibmcloud.go
@@ -1,0 +1,317 @@
+package providers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/softlayer/softlayer-go/datatypes"
+	"github.com/softlayer/softlayer-go/services"
+	"github.com/softlayer/softlayer-go/session"
+	"github.com/softlayer/softlayer-go/sl"
+
+	"github.com/openshift/ofcir/pkg/utils"
+)
+
+// Package 200 are the fast provisioning servers (40-60min provsion)
+const IbmCloudFastProvisioningServer = 200
+
+// TODO: Would love to find a way to list locations where the package is available but
+// I can't for the life of me figure it out, need to revisit
+// I've removed some of the more expensive locations from the list below
+var locations = []string{"DALLAS09", "DALLAS10", "DALLAS12", "DALLAS13", "FRANKFURT", "FRANKFURT04", "FRANKFURT05", "LONDON02", "LONDON04",
+	"LONDON05", "LONDON06", "MILAN", "MONTREAL", "PARIS", "MADRID02", "MADRID04", "MADRID05", "SANJOSE03", "SANJOSE04", "TORONTO",
+	"TORONTO04", "TORONTO05", "WASHINGTON06", "WASHINGTON07"}
+
+type ibmcloudProviderConfig struct {
+	APIKey string `json:"apikey"`
+	Sshkey string `json:"sshkey"`
+	Preset string `json:"preset"`
+}
+
+type ibmcloudProvider struct {
+	config ibmcloudProviderConfig
+	client *session.Session
+}
+
+func IbmcloudProviderFactory(providerInfo string, secretData map[string][]byte) (Provider, error) {
+	config := ibmcloudProviderConfig{}
+
+	if configJSON, ok := secretData["config"]; ok {
+		if err := json.Unmarshal(configJSON, &config); err != nil {
+			return nil, fmt.Errorf("error in provider config json: %w", err)
+		}
+	}
+
+	provider := &ibmcloudProvider{
+		config: config,
+	}
+
+	provider.client = session.New("apikey", provider.config.APIKey)
+	return provider, nil
+}
+
+func (p *ibmcloudProvider) getPackageItems(packageId int) (resp []datatypes.Product_Item) {
+	var mask = "id, itemCategory, keyName,prices[id, hourlyRecurringFee, recurringFee, categories]"
+	var service = services.GetProductPackageService(p.client)
+	receipt, err := service.Id(packageId).Mask(mask).GetItems()
+	if err != nil {
+		return
+	}
+
+	return receipt
+}
+
+func (p *ibmcloudProvider) getStandardPrice(item datatypes.Product_Item) (resp datatypes.Product_Item_Price) {
+	for _, itemPrice := range item.Prices {
+		if itemPrice.LocationGroupId == nil {
+			return itemPrice
+		}
+	}
+	return datatypes.Product_Item_Price{}
+
+}
+
+func (p *ibmcloudProvider) getItemPriceList(packageId int, itemKeyNames []string) (resp []datatypes.Product_Item_Price) {
+
+	items := p.getPackageItems(packageId)
+	var prices []datatypes.Product_Item_Price
+
+	for _, itemKeyName := range itemKeyNames {
+		for _, item := range items {
+			if (*item.KeyName) == itemKeyName {
+				itemPrice := p.getStandardPrice(item)
+				prices = append(prices, itemPrice)
+				break
+			}
+		}
+	}
+
+	return prices
+}
+
+func (p *ibmcloudProvider) serverCreate(pool, presetname string) (string, error) {
+
+	location := locations[rand.Intn(len(locations))]
+
+	hostname := strings.Split(uuid.New().String(), "-")[0]
+	domain := pool + ".ofcir"
+
+	key, err := p.ensureSSHKey(p.config.Sshkey)
+	if err != nil {
+		return "", err
+	}
+
+	server := []datatypes.Hardware{
+		{
+			Hostname: sl.String(hostname),
+			Domain:   sl.String(domain),
+		},
+	}
+
+	// IBMC Servers have to be odered with a range of packages, this is a list of the
+	// minimum required by hourly BM nodes e.g. 1_IP_ADDRESS vs 4_PUBLIC_IP_ADDRESSES
+	// Get a list of available keys with
+	// ibmcloud sl order item-list  BARE_METAL_SERVER
+	required_items := []string{
+		"REBOOT_KVM_OVER_IP",
+		"UNLIMITED_SSL_VPN_USERS_1_PPTP_VPN_USER_PER_ACCOUNT",
+		"OS_CENTOS_STREAM_8_X_64_BIT",
+		"BANDWIDTH_0_GB_2",
+		"1_GBPS_PUBLIC_PRIVATE_NETWORK_UPLINKS",
+		"1_IP_ADDRESS",
+	}
+	// Build a skeleton SoftLayer_Product_Item_Price objects.
+	prices := p.getItemPriceList(IbmCloudFastProvisioningServer, required_items)
+
+	// We need to find the ID of the preset with the required name
+	packageService := services.GetProductPackageService(p.client)
+
+	// ibmcloud sl order preset-list  --prices BARE_METAL_SERVER
+	// e.g. presetname == 1U_4210S_384GB_2X4TB_RAID_1
+	// 1U_4210S_384GB_2X4TB_RAID_1, id = 1278
+	presets, err := packageService.Id(IbmCloudFastProvisioningServer).GetActivePresets()
+	presetId := -1
+	for _, preset := range presets {
+		if *preset.KeyName == presetname {
+			presetId = *preset.Id
+			break
+		}
+	}
+	if presetId == -1 {
+		return "", errors.New("Can't find preset with name " + presetname)
+	}
+
+	orderkeys := []datatypes.Container_Product_Order_SshKeys{
+		{
+			SshKeyIds: []int{*key},
+		},
+	}
+
+	// Build a container_Product_Order object.
+	orderTemplate := datatypes.Container_Product_Order{
+		Quantity:         sl.Int(1),
+		Location:         sl.String(location),
+		PackageId:        sl.Int(IbmCloudFastProvisioningServer),
+		PresetId:         sl.Int(presetId),
+		Prices:           prices,
+		Hardware:         server,
+		UseHourlyPricing: sl.Bool(true),
+		SshKeys:          orderkeys,
+	}
+
+	// Get SoftLayer_Product_Order service.
+	service := services.GetProductOrderService(p.client)
+
+	// Uncomment to "dry-run" the order before placing it
+	//result, err := service.VerifyOrder(&orderTemplate)
+	_, err = service.PlaceOrder(&orderTemplate, sl.Bool(false))
+	if err != nil {
+		return "", err
+	}
+
+	// Nodes don't appear in ibmcloud immediatly, Should we wait for the node to appear?
+	// would prevent a bunch of node not found errors in the logs from acquirecomplete
+	return hostname, nil
+}
+
+func (p *ibmcloudProvider) Acquire(poolSize int, poolName string, poolType string) (Resource, error) {
+
+	res := Resource{}
+	id, err := p.serverCreate(poolName, p.config.Preset)
+	if err != nil {
+		return res, err
+	}
+
+	res.Id = id
+	return res, nil
+}
+
+func (p *ibmcloudProvider) getNodeByName(name string) (*datatypes.Hardware, error) {
+	service := services.GetAccountService(p.client)
+	nodes, err := service.Mask("id;hostname;primaryIpAddress;hardwareStatus;billingItem;hourlyBillingFlag;lastTransaction").GetHardware()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, node := range nodes {
+		if *node.Hostname == name {
+			return &node, nil
+		}
+	}
+	return nil, errors.New("Node node found")
+}
+
+func (p *ibmcloudProvider) ensureSSHKey(newkey string) (*int, error) {
+	sshKeys, err := services.GetAccountService(p.client).GetSshKeys()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, key := range sshKeys {
+		if *key.Key == newkey {
+			return key.Id, nil
+		}
+	}
+	newKey := datatypes.Security_Ssh_Key{}
+	newKey.Key = sl.String(newkey)
+	// TODO: could do with something desciptive here (poolname if available)
+	newKey.Label = sl.String(strings.Split(uuid.New().String(), "-")[0])
+	newKey, err = services.GetSecuritySshKeyService(p.client).CreateObject(&newKey)
+
+	if err != nil {
+		return nil, err
+	}
+	return newKey.Id, nil
+}
+
+func (p *ibmcloudProvider) AcquireCompleted(id string) (bool, Resource, error) {
+
+	res := Resource{
+		Id: id,
+	}
+
+	node, err := p.getNodeByName(id)
+	if err != nil {
+		return false, res, err
+	}
+
+	// This may happen for a short period (20 seconds or so) after a node is initially created
+	if node == nil {
+		return false, res, fmt.Errorf("error getting node: %w", err)
+	}
+
+	// not ready yet
+	if *node.HardwareStatus.Status != "ACTIVE" {
+		return false, res, nil
+	}
+
+	// A node may be "ACTIVE" but for a short period after a new OS is being provisioned,
+	// acquire hasn't completed it just hasn't started. Check the TransactionStatus, it should
+	// be COMPLETE if the node has finished provisioning
+	if *node.LastTransaction.TransactionStatus.Name != "COMPLETE" {
+		return false, res, nil
+	}
+
+	// Hold back on setting nodes to Available until ssh is available
+	if !utils.IsPortOpen(*node.PrimaryIpAddress, "22") {
+		return false, res, nil
+	}
+
+	res.Address = *node.PrimaryIpAddress
+
+	return true, res, nil
+}
+
+func (p *ibmcloudProvider) Clean(id string) error {
+	node, err := p.getNodeByName(id)
+
+	if node == nil {
+		if err != nil {
+			return err
+		}
+		return errors.New("Error getting node")
+	}
+
+	key, err := p.ensureSSHKey(p.config.Sshkey)
+	if err != nil {
+		return err
+	}
+
+	service := services.GetHardwareServerService(p.client)
+	config := datatypes.Container_Hardware_Server_Configuration{}
+	config.SshKeyIds = []int{*key}
+	_, err = service.Id(*node.Id).ReloadOperatingSystem(sl.String("FORCE"), &config)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *ibmcloudProvider) CleanCompleted(id string) (bool, error) {
+	cleaned, _, err := p.AcquireCompleted(id)
+	return cleaned, err
+}
+
+func (p *ibmcloudProvider) Release(id string) error {
+	node, err := p.getNodeByName(id)
+
+	if node == nil {
+		if err != nil {
+			return err
+		}
+		return errors.New("Error getting node")
+	}
+
+	service := services.GetBillingItemService(p.client)
+	_, err = service.Id(*node.BillingItem.Id).CancelItem(sl.Bool(*node.HourlyBillingFlag), sl.Bool(true), sl.String("No longer needed"), sl.String("No longer needed"))
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/providers/providersFactory.go
+++ b/pkg/providers/providersFactory.go
@@ -10,10 +10,11 @@ import (
 type ProviderType string
 
 const (
-	ProviderDummy   ProviderType = "fake-provider"
-	ProviderLibvirt ProviderType = "libvirt"
-	ProviderIronic  ProviderType = "ironic"
-	ProviderEquinix ProviderType = "equinix"
+	ProviderDummy    ProviderType = "fake-provider"
+	ProviderLibvirt  ProviderType = "libvirt"
+	ProviderIronic   ProviderType = "ironic"
+	ProviderEquinix  ProviderType = "equinix"
+	ProviderIbmcloud ProviderType = "ibmcloud"
 )
 
 func NewProvider(pool *ofcirv1.CIPool, poolSecret *v1.Secret) (Provider, error) {
@@ -27,6 +28,8 @@ func NewProvider(pool *ofcirv1.CIPool, poolSecret *v1.Secret) (Provider, error) 
 		return IronicProviderFactory(pool.Spec.ProviderInfo, poolSecret.Data)
 	case ProviderEquinix:
 		return EquinixProviderFactory(pool.Spec.ProviderInfo, poolSecret.Data)
+	case ProviderIbmcloud:
+		return IbmcloudProviderFactory(pool.Spec.ProviderInfo, poolSecret.Data)
 	default:
 		return nil, fmt.Errorf("unknown provider type: %s", pool.Spec.Provider)
 	}


### PR DESCRIPTION
Add provider to support Fixed provision services. These provision faster (40 to 60 minutes) then other packages.

Nodes a added without hourly billing.