### PR TITLE
ironic: include all config in client key

### DIFF
--- a/pkg/providers/ironic.go
+++ b/pkg/providers/ironic.go
@@ -75,7 +75,7 @@ func IronicProviderFactory(providerInfo string, secretData map[string][]byte) (P
 func (p *ironicProvider) UpdateClient(clearcache bool) error {
 	var client *gophercloud.ServiceClient
 
-	key := p.config.Endpoint + p.config.Username + p.config.OSCloud + p.config.CloudYAML
+	key := p.config.Endpoint + p.config.Username + p.config.OSCloud + p.config.CloudYAML + p.config.Image
 	if clearcache {
 		delete(clients, key)
 	}


### PR DESCRIPTION
 this avoids multiple pools wrongly sharing
 the same client and same instance info