### PR TITLE
METAL-1857: Update to go 1.26

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   namespace: openshift
   name: release
-  tag: rhel-9-release-golang-1.25-openshift-4.21
+  tag: rhel-9-release-golang-1.26-openshift-5.0

--- a/cmd/ofcir-api/Dockerfile
+++ b/cmd/ofcir-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine
+FROM golang:1.26-alpine
 RUN mkdir /ofcir
 ADD . /ofcir
 WORKDIR /ofcir

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/ofcir
 
-go 1.25.7
+go 1.26.3
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7


### PR DESCRIPTION
Bump the toolchain to Go 1.26.3 and align CI/build images with the OpenShift 5.0 golang-1.26 build root.