### PR TITLE
METAL-1862: replace custom kind cluster helpers with envfuncs

### DIFF
--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -11,15 +11,14 @@ import (
 	"github.com/vladimirvivien/gexe"
 	"github.com/vladimirvivien/gexe/exec"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/e2e-framework/klient"
 	"sigs.k8s.io/e2e-framework/klient/k8s"
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
 	"sigs.k8s.io/e2e-framework/klient/wait"
 	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
 	"sigs.k8s.io/e2e-framework/support/kind"
 
 	ofcirv1 "github.com/openshift/ofcir/api/v1"
@@ -32,10 +31,7 @@ const (
 	ofcirImageArchive = "/tmp/ofcir-latest.tar"
 )
 
-var (
-	testenv    env.Environment
-	kubeconfig string
-)
+var testenv env.Environment
 
 func TestMain(m *testing.M) {
 	os.Setenv("GO_TEST_TIMEOUT", "10m")
@@ -59,95 +55,12 @@ func TestMain(m *testing.M) {
 	os.Exit(testenv.Run(m))
 }
 
-// This function is required because the current e2e-framework version (0.2.0) has a bug
-// with podman, fixed in the latest version (see https://github.com/kubernetes-sigs/e2e-framework/pull/348).
-// After upgrading ofcir dependencies, this function could be replaced by:
-//
-// envfuncs.CreateKindCluster(kindClusterName)
 func createKindCluster(clusterName string) env.Func {
-	return func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
-		log.Printf("Creating cluster (%s)", clusterName)
-
-		var err error
-		k := kind.NewCluster(clusterName)
-		kubeconfig, err = k.CreateWithConfig(ctx, "kind-config.yaml")
-		if err != nil {
-			return ctx, err
-		}
-
-		// Temporary fix for podman
-		p := runCommand(fmt.Sprintf("sed -i '/enabling experimental podman provider/d' %s", kubeconfig))
-		if p.Err() != nil {
-			return ctx, fmt.Errorf("kind: create cluster failed: %s: %s", p.Err(), p.Result())
-		}
-
-		cfg.WithKubeconfigFile(kubeconfig)
-
-		if err := waitForControlPlane(cfg.Client()); err != nil {
-			return ctx, err
-		}
-
-		type kindContextKey string
-		return context.WithValue(ctx, kindContextKey(clusterName), k), nil
-	}
+	return envfuncs.CreateClusterWithConfig(kind.NewProvider(), clusterName, "kind-config.yaml")
 }
 
-// This function is required because the current e2e-framework version (0.2.0) has a bug
-// with podman, fixed in the latest version (see https://github.com/kubernetes-sigs/e2e-framework/pull/348).
-// After upgrading ofcir dependencies, this function could be replaced by:
-//
-// envfuncs.DestroyKindCluster(kindClusterName)
 func destroyKindCluster(clusterName string) env.Func {
-	return func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
-		log.Printf("Destroying cluster (%s)", clusterName)
-
-		p := runCommand(fmt.Sprintf(`kind delete cluster --name %s`, clusterName))
-		if p.Err() != nil {
-			return ctx, fmt.Errorf("kind: delete cluster failed: %s: %s", p.Err(), p.Result())
-		}
-		if err := os.RemoveAll(kubeconfig); err != nil {
-			return ctx, fmt.Errorf("kind: remove kubeconfig failed: %w", err)
-		}
-		return ctx, nil
-	}
-}
-
-func waitForControlPlane(client klient.Client) error {
-	r, err := resources.New(client.RESTConfig())
-	if err != nil {
-		return err
-	}
-	selector, err := metav1.LabelSelectorAsSelector(
-		&metav1.LabelSelector{
-			MatchExpressions: []metav1.LabelSelectorRequirement{
-				{Key: "component", Operator: metav1.LabelSelectorOpIn, Values: []string{"etcd", "kube-apiserver", "kube-controller-manager", "kube-scheduler"}},
-			},
-		},
-	)
-	if err != nil {
-		return err
-	}
-	// a kind cluster with one control-plane node will have 4 pods running the core apiserver components
-	err = wait.For(conditions.New(r).ResourceListN(&v1.PodList{}, 4, resources.WithLabelSelector(selector.String())))
-	if err != nil {
-		return err
-	}
-	selector, err = metav1.LabelSelectorAsSelector(
-		&metav1.LabelSelector{
-			MatchExpressions: []metav1.LabelSelectorRequirement{
-				{Key: "k8s-app", Operator: metav1.LabelSelectorOpIn, Values: []string{"kindnet", "kube-dns", "kube-proxy"}},
-			},
-		},
-	)
-	if err != nil {
-		return err
-	}
-	// a kind cluster with one control-plane node will have 4 k8s-app pods running networking components
-	err = wait.For(conditions.New(r).ResourceListN(&v1.PodList{}, 4, resources.WithLabelSelector(selector.String())))
-	if err != nil {
-		return err
-	}
-	return nil
+	return envfuncs.DestroyCluster(clusterName)
 }
 
 func ofcirCleanup(ctx context.Context, c *envconf.Config) (context.Context, error) {


### PR DESCRIPTION
The hand-rolled createKindCluster/destroyKindCluster carried a podman workaround (sed hack) and a manual waitForControlPlane that were needed for e2e-framework v0.2.0.
With v0.7.0 the upstream bug (PR #348) is fixed and envfuncs.CreateClusterWithConfig / DestroyCluster handle cluster lifecycle, kubeconfig management, and control-plane readiness out of the box.