### PR TITLE
Fix 504 gateway timeouts on acquire by removing global mutex

### DIFF
--- a/pkg/server/commands/acquire.go
+++ b/pkg/server/commands/acquire.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	ofcirv1 "github.com/openshift/ofcir/api/v1"
@@ -47,9 +48,13 @@ func contains(rtypes []ofcirv1.CIResourceType, rtype ofcirv1.CIResourceType) boo
 	return false
 }
 
-func (c *acquireCmd) Run() error {
+const apiCallTimeout = 10 * time.Second
 
-	pools, err := c.clientset.CIPools(c.namespace).List(context.Background(), v1.ListOptions{})
+func (c *acquireCmd) Run() error {
+	ctx, cancel := context.WithTimeout(context.Background(), apiCallTimeout)
+	defer cancel()
+
+	pools, err := c.clientset.CIPools(c.namespace).List(ctx, v1.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -67,7 +72,7 @@ func (c *acquireCmd) Run() error {
 		return nil
 	}
 
-	allCirs, err := c.clientset.CIResources(c.namespace).List(context.Background(), v1.ListOptions{})
+	allCirs, err := c.clientset.CIResources(c.namespace).List(ctx, v1.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -101,12 +106,12 @@ func (c *acquireCmd) Run() error {
 	})
 
 	// Let's try to look for an available resource in the default pools
-	if c.lookForAvailableResource(cirs, poolsByName) {
+	if c.lookForAvailableResource(ctx, cirs, poolsByName) {
 		return nil
 	}
 
 	// Let's try on the fallback one
-	if c.lookForAvailableResource(fallbacks, poolsByName) {
+	if c.lookForAvailableResource(ctx, fallbacks, poolsByName) {
 		return nil
 	}
 
@@ -114,7 +119,7 @@ func (c *acquireCmd) Run() error {
 	return nil
 }
 
-func (c *acquireCmd) lookForAvailableResource(cirs []ofcirv1.CIResource, poolsByName map[string]ofcirv1.CIPool) bool {
+func (c *acquireCmd) lookForAvailableResource(ctx context.Context, cirs []ofcirv1.CIResource, poolsByName map[string]ofcirv1.CIPool) bool {
 	for _, r := range cirs {
 
 		// Only available resource are eligible to be acquired
@@ -126,7 +131,7 @@ func (c *acquireCmd) lookForAvailableResource(cirs []ofcirv1.CIResource, poolsBy
 		if r.Spec.State != ofcirv1.StateInUse && r.Spec.State != ofcirv1.StateMaintenance {
 
 			r.Spec.State = ofcirv1.StateInUse
-			_, err := c.clientset.CIResources(r.Namespace).Update(context.Background(), &r, v1.UpdateOptions{})
+			_, err := c.clientset.CIResources(r.Namespace).Update(ctx, &r, v1.UpdateOptions{})
 			if err != nil {
 				continue
 			}

--- a/pkg/server/commands/release.go
+++ b/pkg/server/commands/release.go
@@ -3,12 +3,13 @@ package commands
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/ofcir/pkg/utils"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	ofcirv1 "github.com/openshift/ofcir/api/v1"
 	ofcirclientv1 "github.com/openshift/ofcir/pkg/server/clientset/v1"
+	"github.com/openshift/ofcir/pkg/utils"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -30,8 +31,10 @@ func NewReleaseCmd(c *gin.Context, clientset *ofcirclientv1.OfcirV1Client, ns st
 }
 
 func (c *releaseCmd) Run() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 
-	r, err := c.clientset.CIResources(c.namespace).Get(context.Background(), c.cirName, v1.GetOptions{})
+	r, err := c.clientset.CIResources(c.namespace).Get(ctx, c.cirName, v1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			c.context.JSON(http.StatusBadRequest, gin.H{
@@ -50,7 +53,7 @@ func (c *releaseCmd) Run() error {
 	switch r.Status.State {
 	case ofcirv1.StateInUse:
 		r.Spec.State = ofcirv1.StateAvailable
-		_, err := c.clientset.CIResources(r.Namespace).Update(context.Background(), r, v1.UpdateOptions{})
+		_, err := c.clientset.CIResources(r.Namespace).Update(ctx, r, v1.UpdateOptions{})
 		if err != nil {
 			return err
 		}

--- a/pkg/server/commands/status.go
+++ b/pkg/server/commands/status.go
@@ -3,11 +3,12 @@ package commands
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/ofcir/pkg/utils"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	ofcirclientv1 "github.com/openshift/ofcir/pkg/server/clientset/v1"
+	"github.com/openshift/ofcir/pkg/utils"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -29,8 +30,10 @@ func NewStatusCmd(c *gin.Context, clientset *ofcirclientv1.OfcirV1Client, ns str
 }
 
 func (c *statusCmd) Run() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 
-	r, err := c.clientset.CIResources(c.namespace).Get(context.Background(), c.cirName, v1.GetOptions{})
+	r, err := c.clientset.CIResources(c.namespace).Get(ctx, c.cirName, v1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			c.context.JSON(http.StatusBadRequest, gin.H{
@@ -46,7 +49,7 @@ func (c *statusCmd) Run() error {
 		return nil
 	}
 
-	pool, err := c.clientset.CIPools(c.namespace).Get(context.Background(), r.Spec.PoolRef.Name, v1.GetOptions{})
+	pool, err := c.clientset.CIPools(c.namespace).Get(ctx, r.Spec.PoolRef.Name, v1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			c.context.JSON(http.StatusBadRequest, gin.H{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"sync"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/openshift/ofcir/pkg/server/commands"
@@ -20,8 +20,9 @@ import (
 	ofcirclientv1 "github.com/openshift/ofcir/pkg/server/clientset/v1"
 )
 
+const writeTimeout = 30 * time.Second
+
 type OfcirAPI struct {
-	sync.Mutex
 	config    *rest.Config
 	clientset *ofcirclientv1.OfcirV1Client
 	corev1    corev1.CoreV1Interface
@@ -82,7 +83,9 @@ func (o *OfcirAPI) Init(kubeconfig string) error {
 
 func (o *OfcirAPI) AuthRequired() gin.HandlerFunc {
 	return func(ctx *gin.Context) {
-		tokens, err := o.corev1.Secrets("ofcir-system").Get(context.Background(), "ofcir-tokens", metav1.GetOptions{})
+		authCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		tokens, err := o.corev1.Secrets("ofcir-system").Get(authCtx, "ofcir-tokens", metav1.GetOptions{})
 		tokenheader := ctx.Request.Header["X-Ofcirtoken"]
 		if (err != nil) || (len(tokenheader) == 0) {
 			ctx.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"msg": "401 Unauthorized"})
@@ -98,7 +101,14 @@ func (o *OfcirAPI) AuthRequired() gin.HandlerFunc {
 }
 
 func (o *OfcirAPI) Run() {
-	o.router.Run(fmt.Sprintf(":%s", o.port))
+	srv := &http.Server{
+		Addr:         fmt.Sprintf(":%s", o.port),
+		Handler:      o.router,
+		WriteTimeout: writeTimeout,
+		ReadTimeout:  10 * time.Second,
+		IdleTimeout:  120 * time.Second,
+	}
+	srv.ListenAndServe()
 }
 
 func (o *OfcirAPI) handleGetCirStatus(c *gin.Context) {
@@ -112,9 +122,6 @@ func (o *OfcirAPI) handleGetCirStatus(c *gin.Context) {
 }
 
 func (o *OfcirAPI) handleAcquireCir(c *gin.Context) {
-	o.Lock()
-	defer o.Unlock()
-
 	resourceType := c.DefaultQuery("type", string(ofcirv1.TypeCIHost))
 	cmd := commands.NewAcquireCmd(c, o.clientset, o.namespace, resourceType)
 	if err := cmd.Run(); err != nil {
@@ -125,9 +132,6 @@ func (o *OfcirAPI) handleAcquireCir(c *gin.Context) {
 }
 
 func (o *OfcirAPI) handleReleaseCir(c *gin.Context) {
-	o.Lock()
-	defer o.Unlock()
-
 	cirName := c.Param("cirName")
 	cmd := commands.NewReleaseCmd(c, o.clientset, o.namespace, cirName)
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
The process-wide sync.Mutex serialized all acquire/release requests, causing head-of-line blocking when any single K8s API call was slow. Under load, queued requests exceeded the external Route's 30s timeout, resulting in 504 errors even though OFCIR eventually responded 200.

The mutex is unnecessary because the K8s API already provides optimistic concurrency control via resourceVersion conflicts, which the existing `continue` in lookForAvailableResource already handles correctly.

Additionally:
- Add context timeouts (10s) to all K8s API calls to fail fast
- Add HTTP server WriteTimeout (30s) to bound connection lifetime
- Add ReadTimeout and IdleTimeout for connection hygiene

Assisted-By: Claude Opus 4.6