### PR TITLE
Fix 502/404 errors with hierarchical request-scoped contexts

### DIFF
--- a/pkg/server/commands/acquire.go
+++ b/pkg/server/commands/acquire.go
@@ -48,13 +48,19 @@ func contains(rtypes []ofcirv1.CIResourceType, rtype ofcirv1.CIResourceType) boo
 	return false
 }
 
-const apiCallTimeout = 10 * time.Second
+const (
+	overallTimeout = 55 * time.Second
+	apiCallTimeout = 18 * time.Second
+)
 
 func (c *acquireCmd) Run() error {
-	ctx, cancel := context.WithTimeout(context.Background(), apiCallTimeout)
-	defer cancel()
+	overallCtx, overallCancel := context.WithTimeout(c.context.Request.Context(), overallTimeout)
+	defer overallCancel()
 
-	pools, err := c.clientset.CIPools(c.namespace).List(ctx, v1.ListOptions{})
+	listCtx, listCancel := context.WithTimeout(overallCtx, apiCallTimeout)
+	defer listCancel()
+
+	pools, err := c.clientset.CIPools(c.namespace).List(listCtx, v1.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -72,7 +78,10 @@ func (c *acquireCmd) Run() error {
 		return nil
 	}
 
-	allCirs, err := c.clientset.CIResources(c.namespace).List(ctx, v1.ListOptions{})
+	cirsCtx, cirsCancel := context.WithTimeout(overallCtx, apiCallTimeout)
+	defer cirsCancel()
+
+	allCirs, err := c.clientset.CIResources(c.namespace).List(cirsCtx, v1.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -106,12 +115,12 @@ func (c *acquireCmd) Run() error {
 	})
 
 	// Let's try to look for an available resource in the default pools
-	if c.lookForAvailableResource(ctx, cirs, poolsByName) {
+	if c.lookForAvailableResource(overallCtx, cirs, poolsByName) {
 		return nil
 	}
 
 	// Let's try on the fallback one
-	if c.lookForAvailableResource(ctx, fallbacks, poolsByName) {
+	if c.lookForAvailableResource(overallCtx, fallbacks, poolsByName) {
 		return nil
 	}
 
@@ -121,6 +130,9 @@ func (c *acquireCmd) Run() error {
 
 func (c *acquireCmd) lookForAvailableResource(ctx context.Context, cirs []ofcirv1.CIResource, poolsByName map[string]ofcirv1.CIPool) bool {
 	for _, r := range cirs {
+		if ctx.Err() != nil {
+			return false
+		}
 
 		// Only available resource are eligible to be acquired
 		if r.Status.State != ofcirv1.StateAvailable {
@@ -131,7 +143,9 @@ func (c *acquireCmd) lookForAvailableResource(ctx context.Context, cirs []ofcirv
 		if r.Spec.State != ofcirv1.StateInUse && r.Spec.State != ofcirv1.StateMaintenance {
 
 			r.Spec.State = ofcirv1.StateInUse
-			_, err := c.clientset.CIResources(r.Namespace).Update(ctx, &r, v1.UpdateOptions{})
+			updateCtx, updateCancel := context.WithTimeout(ctx, apiCallTimeout)
+			_, err := c.clientset.CIResources(r.Namespace).Update(updateCtx, &r, v1.UpdateOptions{})
+			updateCancel()
 			if err != nil {
 				continue
 			}

--- a/pkg/server/commands/release.go
+++ b/pkg/server/commands/release.go
@@ -31,10 +31,13 @@ func NewReleaseCmd(c *gin.Context, clientset *ofcirclientv1.OfcirV1Client, ns st
 }
 
 func (c *releaseCmd) Run() error {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	overallCtx, overallCancel := context.WithTimeout(c.context.Request.Context(), 55*time.Second)
+	defer overallCancel()
 
-	r, err := c.clientset.CIResources(c.namespace).Get(ctx, c.cirName, v1.GetOptions{})
+	getCtx, getCancel := context.WithTimeout(overallCtx, 18*time.Second)
+	defer getCancel()
+
+	r, err := c.clientset.CIResources(c.namespace).Get(getCtx, c.cirName, v1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			c.context.JSON(http.StatusBadRequest, gin.H{
@@ -53,7 +56,9 @@ func (c *releaseCmd) Run() error {
 	switch r.Status.State {
 	case ofcirv1.StateInUse:
 		r.Spec.State = ofcirv1.StateAvailable
-		_, err := c.clientset.CIResources(r.Namespace).Update(ctx, r, v1.UpdateOptions{})
+		updateCtx, updateCancel := context.WithTimeout(overallCtx, 18*time.Second)
+		defer updateCancel()
+		_, err := c.clientset.CIResources(r.Namespace).Update(updateCtx, r, v1.UpdateOptions{})
 		if err != nil {
 			return err
 		}

--- a/pkg/server/commands/status.go
+++ b/pkg/server/commands/status.go
@@ -30,10 +30,13 @@ func NewStatusCmd(c *gin.Context, clientset *ofcirclientv1.OfcirV1Client, ns str
 }
 
 func (c *statusCmd) Run() error {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	overallCtx, overallCancel := context.WithTimeout(c.context.Request.Context(), 55*time.Second)
+	defer overallCancel()
 
-	r, err := c.clientset.CIResources(c.namespace).Get(ctx, c.cirName, v1.GetOptions{})
+	getCtx, getCancel := context.WithTimeout(overallCtx, 18*time.Second)
+	defer getCancel()
+
+	r, err := c.clientset.CIResources(c.namespace).Get(getCtx, c.cirName, v1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			c.context.JSON(http.StatusBadRequest, gin.H{
@@ -49,7 +52,10 @@ func (c *statusCmd) Run() error {
 		return nil
 	}
 
-	pool, err := c.clientset.CIPools(c.namespace).Get(ctx, r.Spec.PoolRef.Name, v1.GetOptions{})
+	poolCtx, poolCancel := context.WithTimeout(overallCtx, 18*time.Second)
+	defer poolCancel()
+
+	pool, err := c.clientset.CIPools(c.namespace).Get(poolCtx, r.Spec.PoolRef.Name, v1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			c.context.JSON(http.StatusBadRequest, gin.H{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -20,8 +20,6 @@ import (
 	ofcirclientv1 "github.com/openshift/ofcir/pkg/server/clientset/v1"
 )
 
-const writeTimeout = 30 * time.Second
-
 type OfcirAPI struct {
 	config    *rest.Config
 	clientset *ofcirclientv1.OfcirV1Client
@@ -83,7 +81,7 @@ func (o *OfcirAPI) Init(kubeconfig string) error {
 
 func (o *OfcirAPI) AuthRequired() gin.HandlerFunc {
 	return func(ctx *gin.Context) {
-		authCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		authCtx, cancel := context.WithTimeout(ctx.Request.Context(), 5*time.Second)
 		defer cancel()
 		tokens, err := o.corev1.Secrets("ofcir-system").Get(authCtx, "ofcir-tokens", metav1.GetOptions{})
 		tokenheader := ctx.Request.Header["X-Ofcirtoken"]
@@ -102,11 +100,10 @@ func (o *OfcirAPI) AuthRequired() gin.HandlerFunc {
 
 func (o *OfcirAPI) Run() {
 	srv := &http.Server{
-		Addr:         fmt.Sprintf(":%s", o.port),
-		Handler:      o.router,
-		WriteTimeout: writeTimeout,
-		ReadTimeout:  10 * time.Second,
-		IdleTimeout:  120 * time.Second,
+		Addr:        fmt.Sprintf(":%s", o.port),
+		Handler:     o.router,
+		ReadTimeout: 10 * time.Second,
+		IdleTimeout: 120 * time.Second,
 	}
 	srv.ListenAndServe()
 }


### PR DESCRIPTION
A shared 10s context across sequential K8s API calls (List, List,
Update) caused context expiration mid-flow when earlier calls were
slow, resulting in silent Update failures and false 404 "no available
resource" responses. The http.Server WriteTimeout also terminated
connections without a proper HTTP response, causing 502s upstream.

- Add 55s parent context per request derived from the HTTP request
  context, ensuring cancelled clients stop in-flight K8s API work
- Derive per-call child contexts (18s) from the parent to prevent a
  single slow call from starving subsequent operations
- Pass parent context into lookForAvailableResource with an early
  ctx.Err() check to short-circuit when the deadline expires
- Remove WriteTimeout from http.Server to prevent premature drops

Assisted-By: Claude Opus 4.6