### PR TITLE
Fix request timeouts exceeding HAProxy 60s route limit

### DIFF
--- a/pkg/server/commands/acquire.go
+++ b/pkg/server/commands/acquire.go
@@ -49,8 +49,8 @@ func contains(rtypes []ofcirv1.CIResourceType, rtype ofcirv1.CIResourceType) boo
 }
 
 const (
-	overallTimeout = 55 * time.Second
-	apiCallTimeout = 18 * time.Second
+	overallTimeout = 50 * time.Second
+	apiCallTimeout = 15 * time.Second
 )
 
 func (c *acquireCmd) Run() error {

--- a/pkg/server/commands/release.go
+++ b/pkg/server/commands/release.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/gin-gonic/gin"
 	ofcirv1 "github.com/openshift/ofcir/api/v1"
@@ -31,10 +30,10 @@ func NewReleaseCmd(c *gin.Context, clientset *ofcirclientv1.OfcirV1Client, ns st
 }
 
 func (c *releaseCmd) Run() error {
-	overallCtx, overallCancel := context.WithTimeout(c.context.Request.Context(), 55*time.Second)
+	overallCtx, overallCancel := context.WithTimeout(c.context.Request.Context(), overallTimeout)
 	defer overallCancel()
 
-	getCtx, getCancel := context.WithTimeout(overallCtx, 18*time.Second)
+	getCtx, getCancel := context.WithTimeout(overallCtx, apiCallTimeout)
 	defer getCancel()
 
 	r, err := c.clientset.CIResources(c.namespace).Get(getCtx, c.cirName, v1.GetOptions{})
@@ -56,7 +55,7 @@ func (c *releaseCmd) Run() error {
 	switch r.Status.State {
 	case ofcirv1.StateInUse:
 		r.Spec.State = ofcirv1.StateAvailable
-		updateCtx, updateCancel := context.WithTimeout(overallCtx, 18*time.Second)
+		updateCtx, updateCancel := context.WithTimeout(overallCtx, apiCallTimeout)
 		defer updateCancel()
 		_, err := c.clientset.CIResources(r.Namespace).Update(updateCtx, r, v1.UpdateOptions{})
 		if err != nil {

--- a/pkg/server/commands/status.go
+++ b/pkg/server/commands/status.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/gin-gonic/gin"
 	ofcirclientv1 "github.com/openshift/ofcir/pkg/server/clientset/v1"
@@ -30,10 +29,10 @@ func NewStatusCmd(c *gin.Context, clientset *ofcirclientv1.OfcirV1Client, ns str
 }
 
 func (c *statusCmd) Run() error {
-	overallCtx, overallCancel := context.WithTimeout(c.context.Request.Context(), 55*time.Second)
+	overallCtx, overallCancel := context.WithTimeout(c.context.Request.Context(), overallTimeout)
 	defer overallCancel()
 
-	getCtx, getCancel := context.WithTimeout(overallCtx, 18*time.Second)
+	getCtx, getCancel := context.WithTimeout(overallCtx, apiCallTimeout)
 	defer getCancel()
 
 	r, err := c.clientset.CIResources(c.namespace).Get(getCtx, c.cirName, v1.GetOptions{})
@@ -52,7 +51,7 @@ func (c *statusCmd) Run() error {
 		return nil
 	}
 
-	poolCtx, poolCancel := context.WithTimeout(overallCtx, 18*time.Second)
+	poolCtx, poolCancel := context.WithTimeout(overallCtx, apiCallTimeout)
 	defer poolCancel()
 
 	pool, err := c.clientset.CIPools(c.namespace).Get(poolCtx, r.Spec.PoolRef.Name, v1.GetOptions{})


### PR DESCRIPTION
Without kube-rbac-proxy enforcing upstream timeouts, K8s API calls under concurrent load can take 20-30s each, causing handlers to run 55-60s and exceed HAProxy's 60s route timeout. Clients then see "SSL_read: unexpected eof" instead of a proper HTTP response.

Assisted-By: Claude Opus 4.6