### PR TITLE
Raise client-go rate limits to prevent request starvation

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -51,6 +51,9 @@ func (o *OfcirAPI) Init(kubeconfig string) error {
 	if err != nil {
 		return err
 	}
+
+	config.QPS = 50
+	config.Burst = 100
 	o.config = config
 
 	ofcirv1.AddToScheme(scheme.Scheme)


### PR DESCRIPTION
The default rest.Config rate limiter (QPS=5, Burst=10) throttles K8s API calls client-side. After the global mutex was removed, concurrent requests generate 40-60 API calls that saturate the rate limiter, adding seconds of internal queueing that compound into HAProxy timeouts.

Bump to QPS=50, Burst=100 so client-go does not artificially bottleneck requests while the K8s API server's own priority and fairness system handles load management.